### PR TITLE
feat: simplify data dictionary styles (#2743)

### DIFF
--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
@@ -10,11 +10,11 @@ import {
   StyledButton,
 } from "./detailCell.styles";
 import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
-import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
-import { MarkdownRenderer } from "@databiosphere/findable-ui/lib/components/MarkdownRenderer/markdownRenderer";
 import { buildExample } from "./utils";
 import { useState } from "react";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
+import { MarkdownCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/MarkdownCell/markdownCell";
+import { getPartialCellContext } from "../../utils";
 
 export const DetailCell = ({
   row,
@@ -24,19 +24,17 @@ export const DetailCell = ({
     <StyledCell>
       <Grid>
         <Typography variant={TEXT_BODY_500}>Description</Typography>
-        <Typography variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES}>
-          <MarkdownRenderer value={row.original.description} />
-        </Typography>
+        <MarkdownCell
+          {...getPartialCellContext({ values: row.original.description })}
+        />
       </Grid>
       <StyledCollapse in={isIn}>
         {row.original.values && (
           <Grid>
             <Typography variant={TEXT_BODY_500}>Allowed Values</Typography>
-            <Typography
-              variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES}
-            >
-              <MarkdownRenderer value={row.original.values} />
-            </Typography>
+            <MarkdownCell
+              {...getPartialCellContext({ values: row.original.values })}
+            />
           </Grid>
         )}
         {row.original.example && (
@@ -54,11 +52,9 @@ export const DetailCell = ({
         {row.original.rationale && (
           <Grid>
             <Typography variant={TEXT_BODY_500}>Rationale</Typography>
-            <Typography
-              variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES}
-            >
-              {row.original.rationale}
-            </Typography>
+            <MarkdownCell
+              {...getPartialCellContext({ values: row.original.rationale })}
+            />
           </Grid>
         )}
         <Grid>
@@ -68,38 +64,32 @@ export const DetailCell = ({
         {row.original.annotations?.tier && (
           <Grid>
             <Typography variant={TEXT_BODY_500}>Tier</Typography>
-            <Typography
-              variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES}
-            >
-              <MarkdownRenderer
-                value={row.original.annotations.tier as string}
-              />
-            </Typography>
+            <MarkdownCell
+              {...getPartialCellContext({
+                values: row.original.annotations.tier,
+              })}
+            />
           </Grid>
         )}
         {row.original.annotations?.bioNetworks && (
           <Grid>
             <Typography variant={TEXT_BODY_500}>BioNetworks</Typography>
-            <Typography
-              variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES}
-            >
-              <MarkdownRenderer
-                value={(row.original.annotations.bioNetworks as string[]).join(
+            <MarkdownCell
+              {...getPartialCellContext({
+                values: (row.original.annotations.bioNetworks as string[]).join(
                   ", "
-                )}
-              />
-            </Typography>
+                ),
+              })}
+            />
           </Grid>
         )}
         <Grid>
           <Typography variant={TEXT_BODY_500}>AnnData Location</Typography>
-          <Typography variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES}>
-            <MarkdownRenderer
-              value={
-                (row.original.annotations?.annDataLocation as string) || "None"
-              }
-            />
-          </Typography>
+          <MarkdownCell
+            {...getPartialCellContext({
+              values: row.original.annotations?.annDataLocation || "None",
+            })}
+          />
         </Grid>
       </StyledCollapse>
       <StyledButton

--- a/pages/metadata/[dictionary]/index.tsx
+++ b/pages/metadata/[dictionary]/index.tsx
@@ -1,4 +1,4 @@
-import { DataDictionaryView } from "@databiosphere/findable-ui/lib/views/DataDictionaryView/dataDictionaryView";
+import { DataDictionaryView } from "../../../views/DataDictionaryView/dataDictionaryView";
 import { Main } from "@databiosphere/findable-ui/lib/components/Layout/components/ContentLayout/components/Main/main";
 import { useRouter } from "next/router";
 

--- a/theme/common/components.ts
+++ b/theme/common/components.ts
@@ -77,10 +77,6 @@ export const MuiCssBaseline = (theme: Theme): Components["MuiCssBaseline"] => {
         margin: 0,
         paddingLeft: 24,
       },
-      p: {
-        ...theme.typography[TEXT_BODY_400_2_LINES],
-        marginBottom: 8,
-      },
       "p code": {
         backgroundColor: PALETTE.SMOKE_LIGHT,
         fontSize: "inherit",

--- a/views/DataDictionaryView/dataDictionaryView.styles.ts
+++ b/views/DataDictionaryView/dataDictionaryView.styles.ts
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+import { DataDictionaryView } from "@databiosphere/findable-ui/lib/views/DataDictionaryView/dataDictionaryView";
+import { textBody4002Lines } from "@databiosphere/findable-ui/lib/styles/common/mixins/fonts";
+
+export const StyledDataDictionaryView = styled(DataDictionaryView)`
+  .MuiTableContainer-root {
+    .MuiTable-root {
+      .MuiTableBody-root {
+        ${textBody4002Lines};
+        .MuiTableCell-root {
+          font: inherit;
+          line-height: inherit;
+        }
+      }
+    }
+  }
+`;

--- a/views/DataDictionaryView/dataDictionaryView.tsx
+++ b/views/DataDictionaryView/dataDictionaryView.tsx
@@ -1,0 +1,4 @@
+import { StyledDataDictionaryView } from "./dataDictionaryView.styles";
+export const DataDictionaryView = (): JSX.Element => {
+  return <StyledDataDictionaryView />;
+};


### PR DESCRIPTION
This pull request includes updates to improve the rendering of markdown content, refactor styling, and adjust imports for better modularity and maintainability. The most important changes involve replacing `MarkdownRenderer` with `MarkdownCell`, updating typography styles, and refactoring the `DataDictionaryView` component.

### Markdown Rendering Update:
* Replaced `MarkdownRenderer` with `MarkdownCell` in `DetailCell` to enhance markdown rendering and improve context handling by leveraging `getPartialCellContext`. (`detailCell.tsx`: [[1]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L13-R17) [[2]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L27-R37) [[3]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L57-R57) [[4]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L71-L102)

### Styling Improvements:
* Removed redundant paragraph styling (`p`) from `MuiCssBaseline` for cleaner and more consistent typography. (`components.ts`: [theme/common/components.tsL80-L83](diffhunk://#diff-27e174fe1b4104647b38a53a55cb90f527a0a43c325b1afaf6f036e520cbe085L80-L83))
* Added `textBody4002Lines` styling to `StyledDataDictionaryView` to ensure consistent typography across table cells. (`dataDictionaryView.styles.ts`: [views/DataDictionaryView/dataDictionaryView.styles.tsR1-R17](diffhunk://#diff-01deb775050776ade5c4ef0a2674f6bd4359b2f53cf489802a14749135837a1fR1-R17))

### Component Refactoring:
* Refactored `DataDictionaryView` to use a styled wrapper (`StyledDataDictionaryView`) for better separation of concerns and maintainability. (`dataDictionaryView.tsx`: [views/DataDictionaryView/dataDictionaryView.tsxR1-R4](diffhunk://#diff-5b1737eaad1d8816357137b0727ab844854d17fc64fa20b53142775e49ade4bcR1-R4))

### Import Adjustments:
* Updated imports in `index.tsx` to use relative paths for better modularity and to simplify dependency management. (`index.tsx`: [pages/metadata/[dictionary]/index.tsxL1-R1](diffhunk://#diff-3fe0be98ff181588472c36a64ffae82319f19ce9d714d9b0a4bf7314ed21e347L1-R1))