### PR TITLE
chore: updated catalog and updates for dcp52 #2839

### DIFF
--- a/docs/dcp-updates.mdx
+++ b/docs/dcp-updates.mdx
@@ -7,6 +7,21 @@ title: HCA Data Portal Updates
 
 # HCA Data Portal Platform Updates
 
+## August 22, 2025
+
+### New projects (5):
+
+1. [A Single-Cell Atlas Of Human Pediatric Liver Reveals Age-Related Hepatic Gene Signatures](https://data.humancellatlas.org/explore/projects/febdaddd-ad3c-4f4a-820f-ade15c48545a)
+1. [B cell signatures and tertiary lymphoid structures contribute to outcome in head and neck squamous cell carcinoma](https://data.humancellatlas.org/explore/projects/e5ef5c5f-b856-47d1-b643-62c265528060)
+1. [Dental cell type atlas reveals stem and differentiated cell types in mouse and human teeth](https://data.humancellatlas.org/explore/projects/aca93e28-7d87-4aa4-b8ae-498b9b235f46)
+1. [Organoids from human tooth showing epithelial stemness phenotype and differentiation potential](https://data.humancellatlas.org/explore/projects/a9ad7346-54b4-43a9-9055-7512aa532ba0)
+1. [Transcriptional Programming of Normal and Inflamed Human Epidermis at Single-Cell Resolution](https://data.humancellatlas.org/explore/projects/8fd1609b-cd2d-4b4d-bb96-49ae6b8ade2f)
+
+### Updated projects (2):
+
+1. [HCA seed network precise tumor-nephrectomy samples](https://data.humancellatlas.org/explore/projects/29ed827b-c539-4f4c-bb6b-ce8f9173dfb7)
+1. [Single cell landscape of mesenchymal and endothelial cells in healthy human liver](https://data.humancellatlas.org/explore/projects/cea413af-79b3-4f11-8b48-383fe9a65fbe)
+
 ## August 11, 2025
 
 ### New projects (7):

--- a/site-config/data-portal/dev/config.ts
+++ b/site-config/data-portal/dev/config.ts
@@ -23,7 +23,7 @@ import {
 import { SELECTED_MATCH } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 
 const APP_TITLE = "HCA Data Portal";
-const CATALOG = "dcp51";
+const CATALOG = "dcp52";
 export const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPLORER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 export const GIT_HUB_REPO_URL = "https://github.com/DataBiosphere/data-portal";


### PR DESCRIPTION
#### Ticket
#2839 


#### Updates
This pull request updates the HCA Data Portal with the latest project additions and changes, and also updates the data catalog configuration for the development environment.

**Documentation updates:**

* Added a new section for August 22, 2025, listing 5 new projects and 2 updated projects in `docs/dcp-updates.mdx`.

**Configuration updates:**

* Changed the `CATALOG` constant from `"dcp51"` to `"dcp52"` in `site-config/data-portal/dev/config.ts` to point to the latest data catalog.