### PR TITLE
feat: add bioturing link to atlas res under cellxgene collection (#2842)

### DIFF
--- a/components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/sideColumn.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/sideColumn.tsx
@@ -34,7 +34,7 @@ export const SideColumn = (): JSX.Element => {
         <References
           links={[
             ...cxgDataPortal,
-            { label: "BIOTOURING Collection", url: BIOTURING_URL },
+            { label: "BioTuring Collection", url: BIOTURING_URL },
           ]}
           title="Data Exploration Tools"
         />

--- a/components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/sideColumn.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/sideColumn.tsx
@@ -7,13 +7,16 @@ import { Publications } from "../../../../../../../common/Section/components/Pub
 import { References } from "../../../../../../../common/Section/components/References/references";
 import { DataReleasePolicy } from "../../../common/DataReleasePolicy/dataReleasePolicy";
 
+const BIOTURING_URL =
+  "https://talk2data.bioturing.com/?tab=studies&version_id=hca&params=N4IgbgpgTgzglgewHYgFwgBYGMCGIC%2BQA";
+
 export const SideColumn = (): JSX.Element => {
   const { atlas, network } = useAtlas();
   const {
     code,
     contact: atlasContact,
     coordinators: atlasCoordinators,
-    cxgDataPortal,
+    cxgDataPortal = [],
     publications,
   } = atlas;
   const { contact: networkContact, coordinators: networkCoordinators } =
@@ -27,10 +30,14 @@ export const SideColumn = (): JSX.Element => {
         <Publications publications={publications} />
         {/* Code */}
         {code && <References links={code} title="Code" />}
-        {/* CELLxGENE Collection */}
-        {cxgDataPortal && (
-          <References links={cxgDataPortal} title="CZ CELLxGENE Collection" />
-        )}
+        {/* Data Exploration Tools */}
+        <References
+          links={[
+            ...cxgDataPortal,
+            { label: "BIOTOURING Collection", url: BIOTURING_URL },
+          ]}
+          title="Data Exploration Tools"
+        />
         {/* Atlas Coordinators */}
         <Coordinators
           coordinators={atlasCoordinators}

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -35,7 +35,7 @@ function buildCXGDataPortalLink(
   const cxgDataPortalURL = `${CZ_CELLXGENE_DATA_PORTAL_URL}/collections/${cxgId}`;
   return [
     {
-      label: cxgDataPortalURL,
+      label: "CZ CELLxGENE Collection",
       url: cxgDataPortalURL,
     },
   ];


### PR DESCRIPTION
Closes #2842.

This pull request updates the presentation of data exploration tools in the `SideColumn` component for the HCA BioNetworks Atlas overview. The changes unify and clarify how external data exploration resources are displayed to users, and improve the labeling for the CELLxGENE collection link.

Enhancements to data exploration tools display:

* The `SideColumn` component now combines the CELLxGENE collection and a new BioTuring Collection link under a single "Data Exploration Tools" section, making it easier for users to find relevant resources. (`sideColumn.tsx` [components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/sideColumn.tsxL30-R40](diffhunk://#diff-dfe82d5d33dfe15915e73882278baadcc4db97cd7f26259db6b957872e838d67L30-R40))
* Added a constant `BIOTURING_URL` for the BioTuring Collection and included it in the list of data exploration tools. (`sideColumn.tsx` [components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/sideColumn.tsxR10-R19](diffhunk://#diff-dfe82d5d33dfe15915e73882278baadcc4db97cd7f26259db6b957872e838d67R10-R19))

Improvements to link labeling:

* The label for the CELLxGENE collection link is now set to "CZ CELLxGENE Collection" instead of displaying the raw URL, providing a clearer and more user-friendly label. (`network.ts` [utils/network.tsL38-R38](diffhunk://#diff-5d75c387f6babf9730ab3d8c6ef8ec66b67fc265ac9cc201671bcb351dad4215L38-R38))

<img width="2307" height="1124" alt="image" src="https://github.com/user-attachments/assets/9d10751d-c792-4a78-b237-d53dae6e7ab6" />
