### PR TITLE
chore: updated catalog and updates for dcp54 #2853

### DIFF
--- a/docs/dcp-updates.mdx
+++ b/docs/dcp-updates.mdx
@@ -7,6 +7,20 @@ title: HCA Data Portal Updates
 
 # HCA Data Portal Platform Updates
 
+## October 23, 2025
+
+### New projects (3):
+
+1. [Cellular and molecular landscapes of human tendons across the lifespan revealed by spatial and single-cell transcriptomics](https://data.humancellatlas.org/explore/projects/032880e5-2b44-4bfb-8eef-25bb48e7453f)
+1. [Cellular heterogeneity and dynamics of the human uterus in healthy premenopausal women](https://data.humancellatlas.org/explore/projects/8dadf21e-0a44-4fa3-aafc-7633b2a9eaa4)
+1. [Organization of the human intestine at single-cell resolution](https://data.humancellatlas.org/explore/projects/16241d82-3119-4bdd-bba5-5097c0591ba0)
+
+### Updated projects (3):
+
+1. [A human omentum-specific mesothelial-like stromal population inhibits adipogenesis through IGFBP2 secretion](https://data.humancellatlas.org/explore/projects/84d1697f-d4af-42c2-9a50-37fb5842c586)
+1. [Single cell full-length transcriptome of human subcutaneous adipose tissue reveals unique and heterogeneous cell populations](https://data.humancellatlas.org/explore/projects/f77290ae-0d7b-4239-b0fe-3cf2c9e8858d)
+1. [Spatial mapping reveals human adipocyte subpopulations with distinct sensitivities to insulin](https://data.humancellatlas.org/explore/projects/9f7aa401-70e3-4695-951a-30541a1434eb)
+
 ## October 2, 2025
 
 ### New projects (3):

--- a/site-config/data-portal/dev/config.ts
+++ b/site-config/data-portal/dev/config.ts
@@ -23,7 +23,7 @@ import {
 import { SELECTED_MATCH } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 
 const APP_TITLE = "HCA Data Portal";
-const CATALOG = "dcp53";
+const CATALOG = "dcp54";
 export const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPLORER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 export const GIT_HUB_REPO_URL = "https://github.com/DataBiosphere/data-portal";


### PR DESCRIPTION
#### Ticket

#2853 

#### Changes

This pull request updates the HCA Data Portal with new project information and changes the data catalog version used by the application. The most important changes are grouped below:

**Content Updates:**

* Added a new section for October 23, 2025 to `docs/dcp-updates.mdx`, listing 3 new projects and 3 updated projects with links to their details.

**Configuration Updates:**

* Updated the `CATALOG` constant in `site-config/data-portal/dev/config.ts` from `dcp53` to `dcp54`, ensuring the portal uses the latest data catalog version.