### PR TITLE
content: rename 'component atlases' to 'integrated objects' on the atlas detail page (#2872)

### DIFF
--- a/components/HCABioNetworks/Network/Atlas/components/Overview/components/MainColumn/mainColumn.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/Overview/components/MainColumn/mainColumn.tsx
@@ -45,7 +45,7 @@ export const MainColumn = (): JSX.Element => {
         <GridPaper>
           <StyledToolbar>
             <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_500}>
-              Component Atlases
+              Integrated Objects
             </Typography>
           </StyledToolbar>
           {integratedAtlases.length > 0 ? (

--- a/docs/guides/accessing-atlases.mdx
+++ b/docs/guides/accessing-atlases.mdx
@@ -44,7 +44,7 @@ The atlas Overview page contains:
 - The Biological Network, publication, and code associated with the atlas
 - Contact information for the Integration Lead of the atlas
 - Contact information for the Biological Network Coordinators
-- A list of component atlases including the name, tissues, diseases, estimated cell count, and options to explore the
+- A list of integrated objects including the name, tissues, diseases, estimated cell count, and options to explore the
   data using CZ CELLxGENE or by downloading the data
 
 To see all projects in an atlas, select the **Source Datasets** tab on the atlas’s Overview page.


### PR DESCRIPTION
Closes #2872.

This pull request updates terminology in both the UI and documentation to improve consistency and clarity regarding the data presented on the atlas Overview page. The key change is the replacement of "Component Atlases" with "Integrated Objects" throughout the user interface and documentation.

Terminology updates:

* Changed the label in the `MainColumn` component from "Component Atlases" to "Integrated Objects" to reflect updated terminology in the UI (`mainColumn.tsx`).
* Updated the documentation in `accessing-atlases.mdx` to refer to "integrated objects" instead of "component atlases" in the list describing the Overview page contents.

<img width="1574" height="1288" alt="image" src="https://github.com/user-attachments/assets/038d7850-8912-49f3-a076-9b5edfe1c0bb" />

<img width="1570" height="1286" alt="image" src="https://github.com/user-attachments/assets/03a009d3-0a6f-4a06-95cc-f17a632dd0cb" />

