### PR TITLE
feat: gut atlas v1.0 overview tab (#2938)

### DIFF
--- a/components/HCABioNetworks/Network/Atlas/components/Overview/components/MainColumn/mainColumn.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/Overview/components/MainColumn/mainColumn.tsx
@@ -23,7 +23,8 @@ import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/m
 export const MainColumn = (): JSX.Element => {
   const { Description } = useAtlasContent() || {};
   const { atlas } = useAtlas();
-  const { integratedAtlases } = atlas;
+  const { integratedAtlases, tracker } = atlas;
+  const showExplore = !tracker;
   return (
     <>
       {/* Atlas Description */}
@@ -51,8 +52,12 @@ export const MainColumn = (): JSX.Element => {
           </StyledToolbar>
           {integratedAtlases.length > 0 ? (
             <Table
-              columns={getIntegratedAtlasesTableColumns()}
-              gridTemplateColumns="minmax(208px, 1fr) minmax(112px, 0.6fr) minmax(112px, 0.6fr) max-content max-content auto"
+              columns={getIntegratedAtlasesTableColumns(showExplore)}
+              gridTemplateColumns={
+                showExplore
+                  ? "minmax(208px, 1fr) minmax(112px, 0.6fr) minmax(112px, 0.6fr) max-content max-content auto"
+                  : "minmax(208px, 1fr) minmax(112px, 0.6fr) minmax(112px, 0.6fr) max-content auto"
+              }
               items={integratedAtlases}
               tableOptions={TABLE_OPTIONS}
             />

--- a/pages/hca-bio-networks/[network]/atlases/[atlas]/datasets.tsx
+++ b/pages/hca-bio-networks/[network]/atlases/[atlas]/datasets.tsx
@@ -28,9 +28,19 @@ const Page = ({
   atlas,
   network,
   projectsResponses,
+  trackerSourceDatasets,
+  trackerSourceStudies,
 }: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element => {
   return (
-    <AtlasProvider value={{ atlas, network, projectsResponses }}>
+    <AtlasProvider
+      value={{
+        atlas,
+        network,
+        projectsResponses,
+        trackerSourceDatasets,
+        trackerSourceStudies,
+      }}
+    >
       <Detail mainColumn={<MainColumn />} Tabs={<Tabs />} top={<Hero />} />
     </AtlasProvider>
   );

--- a/pages/hca-bio-networks/[network]/atlases/[atlas]/datasets.tsx
+++ b/pages/hca-bio-networks/[network]/atlases/[atlas]/datasets.tsx
@@ -28,8 +28,8 @@ const Page = ({
   atlas,
   network,
   projectsResponses,
-  trackerSourceDatasets,
-  trackerSourceStudies,
+  trackerSourceDatasets = [],
+  trackerSourceStudies = [],
 }: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element => {
   return (
     <AtlasProvider

--- a/pages/hca-bio-networks/[network]/atlases/[atlas]/index.tsx
+++ b/pages/hca-bio-networks/[network]/atlases/[atlas]/index.tsx
@@ -29,9 +29,19 @@ const Page = ({
   atlas,
   network,
   projectsResponses,
+  trackerSourceDatasets,
+  trackerSourceStudies,
 }: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element => {
   return (
-    <AtlasProvider value={{ atlas, network, projectsResponses }}>
+    <AtlasProvider
+      value={{
+        atlas,
+        network,
+        projectsResponses,
+        trackerSourceDatasets,
+        trackerSourceStudies,
+      }}
+    >
       <Detail
         mainColumn={<MainColumn />}
         sideColumn={<SideColumn />}

--- a/pages/hca-bio-networks/[network]/atlases/[atlas]/index.tsx
+++ b/pages/hca-bio-networks/[network]/atlases/[atlas]/index.tsx
@@ -29,8 +29,8 @@ const Page = ({
   atlas,
   network,
   projectsResponses,
-  trackerSourceDatasets,
-  trackerSourceStudies,
+  trackerSourceDatasets = [],
+  trackerSourceStudies = [],
 }: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element => {
   return (
     <AtlasProvider

--- a/viewModelBuilders/viewModelBuilders.ts
+++ b/viewModelBuilders/viewModelBuilders.ts
@@ -346,17 +346,23 @@ function getIntegratedAtlasesAtlasNameColumnDef(): ColumnDef<IntegratedAtlasRow>
 
 /**
  * Returns the table column definition model for the integrated atlases table.
+ * @param showExplore - Whether to include the Explore column (omitted for tracker atlases).
  * @returns integrated atlases table column definition.
  */
-export function getIntegratedAtlasesTableColumns(): ColumnDef<IntegratedAtlasRow>[] {
-  return [
+export function getIntegratedAtlasesTableColumns(
+  showExplore = true
+): ColumnDef<IntegratedAtlasRow>[] {
+  const columns: ColumnDef<IntegratedAtlasRow>[] = [
     getIntegratedAtlasesAtlasNameColumnDef(),
     getAtlasesTissueColumnDef(),
     getAtlasesDiseaseColumnDef(),
     getAtlasesCellCountColumnDef(),
-    getAtlasesExploreColumnDef(),
-    getAtlasesActionsColumnDef(),
   ];
+  if (showExplore) {
+    columns.push(getAtlasesExploreColumnDef());
+  }
+  columns.push(getAtlasesActionsColumnDef());
+  return columns;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Wire `trackerSourceDatasets` and `trackerSourceStudies` through `AtlasProvider` in both `index.tsx` and `datasets.tsx` page components
- Omit Explore column from integrated objects table for tracker atlases (no CELLxGENE explorer URLs)
- Add `showExplore` parameter to `getIntegratedAtlasesTableColumns()` (defaults `true` for backward compatibility)
- Adjust grid template columns when Explore is omitted
- Side column already handles tracker atlases gracefully (empty CXG links, "None" publications)

## Test plan
- [x] TypeScript compiles cleanly
- [x] ESLint passes
- [x] Prettier passes
- [x] Visit `/hca-bio-networks/gut/atlases/gut-v1-0` — Overview tab shows description + 13 integrated objects (no Explore column)
- [x] Visit `/hca-bio-networks/lung/atlases/lung-v1-0` — Lung atlas unchanged (Explore column still present)

Closes #2938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2313" height="1274" alt="image" src="https://github.com/user-attachments/assets/018ac8fe-b09d-43e7-b548-1c3fe737deb3" />
