### PR TITLE
feat: gut atlas v1.0 source datasets tab (#2939)

### DIFF
--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/project/options.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/project/options.ts
@@ -1,6 +1,6 @@
 import { COLUMN_IDENTIFIER } from "@databiosphere/findable-ui/lib/components/Table/common/columnIdentifier";
-import { TableOptions } from "@tanstack/react-table";
-import { ProjectsResponse } from "../../../../../../../../apis/azul/hca-dcp/common/responses";
+import type { TableOptions } from "@tanstack/react-table";
+import type { ProjectsResponse } from "../../../../../../../../../../apis/azul/hca-dcp/common/responses";
 
 export const TABLE_OPTIONS: Partial<TableOptions<ProjectsResponse>> = {
   enableRowPosition: false,

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/columns.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/columns.ts
@@ -1,0 +1,63 @@
+import { sortingFn } from "@databiosphere/findable-ui/lib/components/Table/common/utils";
+import type { ColumnDef } from "@tanstack/react-table";
+import * as C from "../../../../../../../../..";
+import type { TrackerSourceDataset } from "../../../../../../../../../../@types/network";
+import {
+  buildNTagProps,
+  renderNTagCell,
+} from "../../../../../../../../../common/Table/components/Cell/components/NTagCell/utils";
+import {
+  buildPinnedNTagProps,
+  renderPinnedNTagCell,
+} from "../../../../../../../../../common/Table/components/Cell/components/PinnedNTagCell/utils";
+import { DISEASE as DISEASE_ENUM } from "../../../../../../../../../../viewModelBuilders/entities";
+import { renderCellCount } from "./viewBuilder";
+
+const CELL_COUNT = {
+  accessorKey: "cellCount",
+  cell: renderCellCount,
+  header: "Cell Count",
+  meta: { width: { max: "1fr", min: "100px" } },
+  sortingFn: "alphanumeric",
+} as ColumnDef<TrackerSourceDataset>;
+
+const DISEASE = {
+  accessorKey: "disease",
+  cell: renderPinnedNTagCell(
+    buildPinnedNTagProps("diseases", "disease", [DISEASE_ENUM.NORMAL])
+  ),
+  header: "Disease",
+  meta: { width: { max: "1fr", min: "100px" } },
+  sortingFn,
+} as ColumnDef<TrackerSourceDataset>;
+
+const DOWNLOAD = {
+  accessorKey: "download",
+  cell: C.TrackerDownloadCell,
+  enableSorting: false,
+  header: "Download",
+  meta: { width: "auto" },
+} as ColumnDef<TrackerSourceDataset>;
+
+const TISSUE = {
+  accessorKey: "tissue",
+  cell: renderNTagCell(buildNTagProps("tissues", "tissue")),
+  header: "Tissue",
+  meta: { width: { max: "1fr", min: "100px" } },
+  sortingFn,
+} as ColumnDef<TrackerSourceDataset>;
+
+const TITLE = {
+  accessorKey: "title",
+  header: "Dataset",
+  meta: { columnPinned: true, width: { max: "2fr", min: "200px" } },
+  sortingFn,
+} as ColumnDef<TrackerSourceDataset>;
+
+export const COLUMNS: ColumnDef<TrackerSourceDataset>[] = [
+  TITLE,
+  TISSUE,
+  DISEASE,
+  CELL_COUNT,
+  DOWNLOAD,
+];

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/hook.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/hook.ts
@@ -1,0 +1,31 @@
+import { SORT_DIRECTION } from "@databiosphere/findable-ui/lib/config/entities";
+import { Table, useReactTable } from "@tanstack/react-table";
+import type { TrackerSourceDataset } from "../../../../../../../../../../@types/network";
+import { CORE_OPTIONS } from "../../../../../../../../../common/Table/options/core/constants";
+import { SORTING_OPTIONS } from "../../../../../../../../../common/Table/options/sorting/constants";
+import { COLUMNS } from "./columns";
+
+/**
+ * Returns a configured TanStack table instance for tracker source datasets.
+ * @param data - Tracker source datasets.
+ * @returns table instance.
+ */
+export const useTable = (
+  data: TrackerSourceDataset[]
+): Table<TrackerSourceDataset> => {
+  return useReactTable<TrackerSourceDataset>({
+    columns: COLUMNS,
+    data,
+    ...CORE_OPTIONS,
+    ...SORTING_OPTIONS,
+    enableRowPosition: false,
+    enableRowPreview: false,
+    getRowId: (row) => row.id,
+    initialState: {
+      sorting: [{ desc: SORT_DIRECTION.ASCENDING, id: "title" }],
+    },
+    state: {
+      columnVisibility: {},
+    },
+  });
+};

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/table.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/table.tsx
@@ -17,7 +17,7 @@ export const Table = ({ data }: Props): JSX.Element => {
     <FluidPaper elevation={0}>
       <GridPaper>
         {table.getRowCount() === 0 ? (
-          <div>No datasets</div>
+          <div>No Source Datasets</div>
         ) : (
           <CommonTable table={table} />
         )}

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/table.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/table.tsx
@@ -1,0 +1,27 @@
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
+import { GridPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import { JSX } from "react";
+import { Table as CommonTable } from "../../../../../../../../../common/Table/table";
+import { useTable } from "./hook";
+import { Props } from "./types";
+
+/**
+ * Tracker source datasets table for the Datasets tab.
+ * @param props - Component props.
+ * @param props.data - Tracker source datasets.
+ * @returns table of tracker source datasets, or empty state if no data.
+ */
+export const Table = ({ data }: Props): JSX.Element => {
+  const table = useTable(data);
+  return (
+    <FluidPaper elevation={0}>
+      <GridPaper>
+        {table.getRowCount() === 0 ? (
+          <div>No datasets</div>
+        ) : (
+          <CommonTable table={table} />
+        )}
+      </GridPaper>
+    </FluidPaper>
+  );
+};

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/types.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/types.ts
@@ -1,0 +1,5 @@
+import type { TrackerSourceDataset } from "../../../../../../../../../../@types/network";
+
+export interface Props {
+  data: TrackerSourceDataset[];
+}

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/viewBuilder.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/viewBuilder.ts
@@ -1,0 +1,16 @@
+import { CellContext } from "@tanstack/react-table";
+import type { TrackerSourceDataset } from "../../../../../../../../../../@types/network";
+
+/**
+ * Returns the cell count.
+ * @param ctx - Cell context.
+ * @returns cell count as a formatted string.
+ */
+export function renderCellCount(
+  ctx: CellContext<TrackerSourceDataset, string>
+): string {
+  const { row } = ctx;
+  const { original } = row;
+  const { cellCount } = original;
+  return cellCount.toLocaleString();
+}

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/viewBuilder.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/viewBuilder.ts
@@ -7,7 +7,7 @@ import type { TrackerSourceDataset } from "../../../../../../../../../../@types/
  * @returns cell count as a formatted string.
  */
 export function renderCellCount(
-  ctx: CellContext<TrackerSourceDataset, string>
+  ctx: CellContext<TrackerSourceDataset, number>
 ): string {
   const { row } = ctx;
   const { original } = row;

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/mainColumn.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/mainColumn.tsx
@@ -1,17 +1,19 @@
-import { JSX } from "react";
 import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { BackPageContentSingleColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
+import { JSX } from "react";
 import { AtlasDatasetsDescription } from "../../../../../../../../content";
 import { useAtlas } from "../../../../../../../../contexts/atlasContext";
 import { useSiteConfig } from "../../../../../../../../hooks/useSiteConfig";
 import { getProjectsTableColumns } from "../../../../../../../../viewModelBuilders/viewModelBuilders";
 import { MDXSection } from "../../../../../../../common/Section/section.styles";
 import { DetailViewTable } from "../../../../../../../common/Table/table.styles";
-import { TABLE_OPTIONS } from "./constants";
+import { TABLE_OPTIONS } from "./Table/project/options";
+import { Table as TrackerSourceDatasetsTable } from "./Table/tracker/table";
 
 export const MainColumn = (): JSX.Element => {
   const { browserURL } = useSiteConfig();
-  const { projectsResponses } = useAtlas();
+  const { atlas, projectsResponses, trackerSourceDatasets = [] } = useAtlas();
+  const isTracker = Boolean(atlas.tracker);
   return (
     <BackPageContentSingleColumn>
       {/* Atlas Datasets Description */}
@@ -21,15 +23,19 @@ export const MainColumn = (): JSX.Element => {
         </MDXSection>
       </FluidPaper>
       {/* Atlas Datasets */}
-      <DetailViewTable
-        columns={getProjectsTableColumns(browserURL)}
-        gridTemplateColumns="minmax(484px, 1fr) repeat(4, minmax(152px, 1fr)) max-content"
-        items={projectsResponses}
-        noResultsTitle={"No Source Datasets"}
-        Paper={FluidPaper}
-        tableOptions={TABLE_OPTIONS}
-        tools={null}
-      />
+      {isTracker ? (
+        <TrackerSourceDatasetsTable data={trackerSourceDatasets} />
+      ) : (
+        <DetailViewTable
+          columns={getProjectsTableColumns(browserURL)}
+          gridTemplateColumns="minmax(484px, 1fr) repeat(4, minmax(152px, 1fr)) max-content"
+          items={projectsResponses}
+          noResultsTitle={"No Source Datasets"}
+          Paper={FluidPaper}
+          tableOptions={TABLE_OPTIONS}
+          tools={null}
+        />
+      )}
     </BackPageContentSingleColumn>
   );
 };

--- a/components/common/Table/components/Cell/components/NTagCell/utils.tsx
+++ b/components/common/Table/components/Cell/components/NTagCell/utils.tsx
@@ -1,0 +1,38 @@
+import { NTagCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/NTagCell/nTagCell";
+import { CellContext, RowData } from "@tanstack/react-table";
+import { ComponentProps, JSX } from "react";
+
+/**
+ * Builds props for NTagCell component.
+ * @param label - Label for NTagCell component.
+ * @param entityKey - Key of the entity to get values for NTagCell component.
+ * @returns Props for NTagCell component.
+ */
+export const buildNTagProps = <T extends RowData>(
+  label: string,
+  entityKey: keyof T
+): ((entity: T) => ComponentProps<typeof NTagCell>) => {
+  return (entity): ComponentProps<typeof NTagCell> => {
+    return {
+      label,
+      values: entity[entityKey] as unknown as string[],
+    };
+  };
+};
+
+/**
+ * Returns NTagCell component.
+ * @param propGetter - Fn that returns props for NTagCell component.
+ * @returns NTagCell component.
+ */
+export function renderNTagCell<T extends RowData>(
+  propGetter: (data: T) => ComponentProps<typeof NTagCell>
+): (ctx: CellContext<T, unknown>) => JSX.Element {
+  const Component = ({ row }: CellContext<T, unknown>): JSX.Element => (
+    <NTagCell {...propGetter(row.original)} />
+  );
+
+  Component.displayName = "NTagCell";
+
+  return Component;
+}

--- a/components/common/Table/components/Cell/components/PinnedNTagCell/utils.tsx
+++ b/components/common/Table/components/Cell/components/PinnedNTagCell/utils.tsx
@@ -1,0 +1,47 @@
+import { CellContext, RowData } from "@tanstack/react-table";
+import { ComponentProps, JSX } from "react";
+import {
+  PinnedNTagCell,
+  PinnedNTagCellProps,
+} from "../../../../../../common/NTagCell/components/PinnedNTagCell/pinnedNTagCell";
+import { partitionMetadataValues } from "../../../../../../../viewModelBuilders/viewModelBuilders";
+
+/**
+ * Builds props for PinnedNTagCell component.
+ * @param label - Label for PinnedNTagCell component.
+ * @param entityKey - Key of the entity to get values for PinnedNTagCell component.
+ * @param pinned - Values to pin to the front.
+ * @returns Props for PinnedNTagCell component.
+ */
+export const buildPinnedNTagProps = <T extends RowData>(
+  label: string,
+  entityKey: keyof T,
+  pinned: string[]
+): ((entity: T) => ComponentProps<typeof PinnedNTagCell>) => {
+  return (entity): PinnedNTagCellProps => {
+    return {
+      label,
+      values: partitionMetadataValues(
+        entity[entityKey] as unknown as string[],
+        pinned
+      ),
+    };
+  };
+};
+
+/**
+ * Returns PinnedNTagCell component.
+ * @param propGetter - Fn that returns props for PinnedNTagCell component.
+ * @returns PinnedNTagCell component.
+ */
+export function renderPinnedNTagCell<T extends RowData>(
+  propGetter: (data: T) => ComponentProps<typeof PinnedNTagCell>
+): (ctx: CellContext<T, unknown>) => JSX.Element {
+  const Component = ({ row }: CellContext<T, unknown>): JSX.Element => (
+    <PinnedNTagCell {...propGetter(row.original)} />
+  );
+
+  Component.displayName = "PinnedNTagCell";
+
+  return Component;
+}

--- a/components/common/Table/components/Cell/components/TrackerDownloadCell/trackerDownloadCell.tsx
+++ b/components/common/Table/components/Cell/components/TrackerDownloadCell/trackerDownloadCell.tsx
@@ -1,0 +1,32 @@
+import { JSX } from "react";
+import { useAtlas } from "../../../../../../../contexts/atlasContext";
+import { CXGDownloadCell } from "../CXGDownloadCell/cxgDownloadCell";
+import type { TrackerDownloadCellProps } from "./types";
+import { buildDatasetAssets } from "./utils";
+
+/**
+ * Download cell for tracker source datasets. Reads network and atlas
+ * tracker config from AtlasContext to construct the S3 download URL.
+ * @param props - Cell context for the tracker source dataset row.
+ * @param props.row - Table row containing the tracker source dataset.
+ * @returns CXGDownloadCell with tracker dataset assets, or null if not a tracker atlas.
+ */
+export const TrackerDownloadCell = ({
+  row,
+}: TrackerDownloadCellProps): JSX.Element | null => {
+  const { atlas, network } = useAtlas();
+  const { tracker } = atlas;
+  if (!tracker) return null;
+  const sourceDataset = row.original;
+  return (
+    <CXGDownloadCell
+      datasetAssets={buildDatasetAssets(
+        sourceDataset,
+        network.key,
+        tracker.shortNameSlug,
+        tracker.version
+      )}
+      title={sourceDataset.title}
+    />
+  );
+};

--- a/components/common/Table/components/Cell/components/TrackerDownloadCell/types.ts
+++ b/components/common/Table/components/Cell/components/TrackerDownloadCell/types.ts
@@ -1,0 +1,7 @@
+import type { CellContext } from "@tanstack/react-table";
+import type { TrackerSourceDataset } from "../../../../../../../@types/network";
+
+export type TrackerDownloadCellProps = CellContext<
+  TrackerSourceDataset,
+  unknown
+>;

--- a/components/common/Table/components/Cell/components/TrackerDownloadCell/utils.ts
+++ b/components/common/Table/components/Cell/components/TrackerDownloadCell/utils.ts
@@ -1,0 +1,29 @@
+import type {
+  DatasetAsset,
+  TrackerSourceDataset,
+} from "../../../../../../../@types/network";
+import { buildTrackerSourceDatasetAsset } from "../../../../../../../utils/trackerNetwork";
+
+/**
+ * Builds dataset assets for a tracker source dataset download.
+ * @param sourceDataset - Tracker source dataset.
+ * @param networkKey - Network key (e.g., "gut").
+ * @param shortNameSlug - Atlas short name slug (e.g., "gut").
+ * @param version - Atlas version (e.g., "v1.0").
+ * @returns dataset assets array.
+ */
+export function buildDatasetAssets(
+  sourceDataset: TrackerSourceDataset,
+  networkKey: string,
+  shortNameSlug: string,
+  version: string
+): DatasetAsset[] {
+  return [
+    buildTrackerSourceDatasetAsset(
+      sourceDataset,
+      networkKey,
+      shortNameSlug,
+      version
+    ),
+  ];
+}

--- a/components/common/Table/options/core/constants.ts
+++ b/components/common/Table/options/core/constants.ts
@@ -1,0 +1,11 @@
+import { ROW_POSITION } from "@databiosphere/findable-ui/lib/components/Table/features/RowPosition/constants";
+import { ROW_PREVIEW } from "@databiosphere/findable-ui/lib/components/Table/features/RowPreview/constants";
+import { CoreOptions, getCoreRowModel, RowData } from "@tanstack/react-table";
+
+export const CORE_OPTIONS: Pick<
+  CoreOptions<RowData>,
+  "_features" | "getCoreRowModel"
+> = {
+  _features: [ROW_POSITION, ROW_PREVIEW],
+  getCoreRowModel: getCoreRowModel(),
+};

--- a/components/common/Table/options/sorting/constants.ts
+++ b/components/common/Table/options/sorting/constants.ts
@@ -1,0 +1,18 @@
+import {
+  getSortedRowModel,
+  RowData,
+  SortingOptions,
+} from "@tanstack/react-table";
+
+export const SORTING_OPTIONS: Pick<
+  SortingOptions<RowData>,
+  | "enableSorting"
+  | "enableSortingInteraction"
+  | "enableSortingRemoval"
+  | "getSortedRowModel"
+> = {
+  enableSorting: true,
+  enableSortingInteraction: true,
+  enableSortingRemoval: false, // false i.e. toggling the sorting on a column will not remove sorting on the column.
+  getSortedRowModel: getSortedRowModel(),
+};

--- a/components/common/Table/table.tsx
+++ b/components/common/Table/table.tsx
@@ -1,0 +1,38 @@
+import { TableBody } from "@databiosphere/findable-ui/lib/components/Detail/components/Table/components/TableBody/tableBody";
+import { TableHead } from "@databiosphere/findable-ui/lib/components/Table/components/TableHead/tableHead";
+import { GridTable } from "@databiosphere/findable-ui/lib/components/Table/table.styles";
+import { getColumnTrackSizing } from "@databiosphere/findable-ui/lib/components/TableCreator/options/columnTrackSizing/utils";
+import { useCurrentBreakpoint } from "@databiosphere/findable-ui/lib/hooks/useCurrentBreakpoint";
+import { TableContainer } from "@mui/material";
+import { RowData } from "@tanstack/react-table";
+import { JSX } from "react";
+import { Props } from "./types";
+import { getRowDirection } from "./utils";
+
+/**
+ * Table component that renders a table using the provided table instance.
+ * @param props - Component props.
+ * @param props.className - Optional class name.
+ * @param props.table - Table instance.
+ * @returns The rendered table component.
+ */
+export const Table = <T extends RowData>({
+  className,
+  table,
+}: Props<T>): JSX.Element => {
+  const bp = useCurrentBreakpoint();
+  const rowDirection = getRowDirection(bp);
+  return (
+    <TableContainer className={className}>
+      <GridTable
+        collapsable
+        gridTemplateColumns={getColumnTrackSizing(
+          table.getVisibleFlatColumns()
+        )}
+      >
+        <TableHead tableInstance={table} />
+        <TableBody rowDirection={rowDirection} tableInstance={table} />
+      </GridTable>
+    </TableContainer>
+  );
+};

--- a/components/common/Table/types.ts
+++ b/components/common/Table/types.ts
@@ -1,0 +1,6 @@
+import { BaseComponentProps } from "@databiosphere/findable-ui/lib/components/types";
+import { RowData, Table } from "@tanstack/react-table";
+
+export interface Props<T extends RowData> extends BaseComponentProps {
+  table: Table<T>;
+}

--- a/components/common/Table/utils.ts
+++ b/components/common/Table/utils.ts
@@ -1,0 +1,12 @@
+import { ROW_DIRECTION } from "@databiosphere/findable-ui/lib/components/Table/common/entities";
+import { Breakpoint } from "@mui/material";
+
+/**
+ * Returns the row direction based on the breakpoint.
+ * @param bp - The breakpoint.
+ * @returns The row direction.
+ */
+export function getRowDirection(bp?: Breakpoint): ROW_DIRECTION {
+  if (bp === "xs") return ROW_DIRECTION.VERTICAL;
+  return ROW_DIRECTION.DEFAULT;
+}

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -25,5 +25,6 @@ export { IconLink } from "./common/IconLink/iconLink";
 export { PinnedNTagCell } from "./common/NTagCell/components/PinnedNTagCell/pinnedNTagCell";
 export { BioNetworkCell } from "./common/Table/components/Cell/components/BioNetworkCell/bioNetworkCell";
 export { CXGDownloadCell } from "./common/Table/components/Cell/components/CXGDownloadCell/cxgDownloadCell";
+export { TrackerDownloadCell } from "./common/Table/components/Cell/components/TrackerDownloadCell/trackerDownloadCell";
 export { AnalysisPortalCell } from "./HCABioNetworks/Network/Atlas/components/Overview/components/MainColumn/components/AnalysisPortalCell/analysisPortalCell";
 export { Content } from "./Layout/components/Content/content";

--- a/viewModelBuilders/viewModelBuilders.ts
+++ b/viewModelBuilders/viewModelBuilders.ts
@@ -6,7 +6,7 @@ import {
   REL_ATTRIBUTE,
 } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { ColumnDef } from "@tanstack/react-table";
-import {
+import type {
   Atlas,
   AtlasesRow,
   AtlasRow,
@@ -536,7 +536,7 @@ function initAtlasRow(): AtlasesRow {
  * @param pinned - Values to pin.
  * @returns metadata tuple containing pinned values and non-pinned values.
  */
-function partitionMetadataValues(
+export function partitionMetadataValues(
   values: MetadataValue[],
   pinned: MetadataValue[]
 ): MetadataValueTuple {


### PR DESCRIPTION
## Summary
- Add tracker source datasets table to the Datasets tab for tracker-sourced atlases
- Create `TrackerDownloadCell` component that reads atlas context to build S3 download URLs
- Create `PinnedNTagCell/utils.tsx` with `buildPinnedNTagProps` and `renderPinnedNTagCell` (matching existing `NTagCell/utils.tsx` pattern)
- Column definitions in local `Table/tracker/columns.ts` following tracker repo pattern
- Table uses `useReactTable` hook with sorting, column pinning
- Non-tracker atlases continue to use existing `ProjectsResponse` table unchanged
- Export `partitionMetadataValues` from `viewModelBuilders.ts` for reuse

## Test plan
- [x] TypeScript compiles cleanly
- [x] ESLint passes
- [x] Prettier passes
- [x] Visit `/hca-bio-networks/gut/atlases/gut-v1-0/datasets` — Source Datasets tab shows 56 tracker datasets with Dataset, Tissue, Disease, Cell Count, Download columns
- [x] Download buttons construct correct S3 URLs
- [x] Visit `/hca-bio-networks/lung/atlases/lung-v1-0/datasets` — Lung datasets tab unchanged

Closes #2939

🤖 Generated with [Claude Code](https://claude.com/claude-code)