### PR TITLE
feat: gut atlas v1.0 source studies tab (#2940)

### DIFF
--- a/@types/network.ts
+++ b/@types/network.ts
@@ -227,9 +227,13 @@ export interface TrackerSourceDataset {
 
 export interface TrackerSourceStudy {
   cellxgeneCollectionId: string | null;
-  doi: string;
-  journal: string;
-  publicationDate: string;
+  contactEmail: string | null;
+  doi: string | null;
+  doiStatus: string;
+  hcaProjectId: string | null;
+  id: string;
+  journal: string | null;
+  publicationDate: string | null;
   referenceAuthor: string;
   sourceDatasetCount: number;
   title: string;

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/accessor.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/accessor.ts
@@ -2,8 +2,9 @@ import type { TrackerSourceStudy } from "../../../../../../../../../../@types/ne
 
 /**
  * Builds a formatted citation string for a source study.
- * Published studies display as "Author (Year) Journal".
- * Unpublished studies display as "Author - Unpublished".
+ * - No DOI: "Author - Unpublished"
+ * - DOI but missing date/journal: "Author"
+ * - DOI with date and journal: "Author (Year) Journal"
  * @param row - Tracker source study.
  * @returns formatted citation string.
  */

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/accessor.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/accessor.ts
@@ -1,0 +1,18 @@
+import type { TrackerSourceStudy } from "../../../../../../../../../../@types/network";
+
+/**
+ * Builds a formatted citation string for a source study.
+ * Published studies display as "Author (Year) Journal".
+ * Unpublished studies display as "Author - Unpublished".
+ * @param row - Tracker source study.
+ * @returns formatted citation string.
+ */
+export function buildSourceStudy(row: TrackerSourceStudy): string {
+  if (!row.doi) return `${row.referenceAuthor} - Unpublished`;
+
+  if (!row.publicationDate || !row.journal) return row.referenceAuthor;
+
+  const publicationYear = new Date(row.publicationDate).getFullYear();
+
+  return `${row.referenceAuthor} (${publicationYear}) ${row.journal}`;
+}

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/columns.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/columns.ts
@@ -1,0 +1,43 @@
+import { sortingFn } from "@databiosphere/findable-ui/lib/components/Table/common/utils";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { TrackerSourceStudy } from "../../../../../../../../../../@types/network";
+import { buildSourceStudy } from "./accessor";
+import { renderHCADataRepository, renderSourceStudy } from "./viewBuilder";
+
+const HCA_DATA_REPOSITORY = {
+  accessorKey: "hcaProjectId",
+  cell: renderHCADataRepository,
+  enableSorting: false,
+  header: "HCA Data Repository",
+  meta: { width: "auto" },
+} as ColumnDef<TrackerSourceStudy>;
+
+const SOURCE_DATASET_COUNT = {
+  accessorKey: "sourceDatasetCount",
+  header: "Datasets",
+  meta: { width: { max: "0.5fr", min: "140px" } },
+  sortingFn: "alphanumeric",
+} as ColumnDef<TrackerSourceStudy>;
+
+const SOURCE_STUDY = {
+  accessorFn: buildSourceStudy,
+  cell: renderSourceStudy,
+  header: "Source Study",
+  id: "sourceStudy",
+  meta: { width: { max: "1.2fr", min: "200px" } },
+  sortingFn,
+} as ColumnDef<TrackerSourceStudy>;
+
+const TITLE = {
+  accessorKey: "title",
+  header: "Title",
+  meta: { columnPinned: true, width: { max: "2fr", min: "200px" } },
+  sortingFn,
+} as ColumnDef<TrackerSourceStudy>;
+
+export const COLUMNS: ColumnDef<TrackerSourceStudy>[] = [
+  SOURCE_STUDY,
+  TITLE,
+  SOURCE_DATASET_COUNT,
+  HCA_DATA_REPOSITORY,
+];

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/hook.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/hook.ts
@@ -1,0 +1,35 @@
+import { SORT_DIRECTION } from "@databiosphere/findable-ui/lib/config/entities";
+import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
+import { Table, useReactTable } from "@tanstack/react-table";
+import type { TrackerSourceStudy } from "../../../../../../../../../../@types/network";
+import { CORE_OPTIONS } from "../../../../../../../../../common/Table/options/core/constants";
+import { SORTING_OPTIONS } from "../../../../../../../../../common/Table/options/sorting/constants";
+import { COLUMNS } from "./columns";
+
+/**
+ * Returns a configured TanStack table instance for tracker source studies.
+ * @param data - Tracker source studies.
+ * @returns table instance.
+ */
+export const useTable = (
+  data: TrackerSourceStudy[]
+): Table<TrackerSourceStudy> => {
+  const { config } = useConfig();
+
+  return useReactTable<TrackerSourceStudy>({
+    columns: COLUMNS,
+    data,
+    ...CORE_OPTIONS,
+    ...SORTING_OPTIONS,
+    enableRowPosition: false,
+    enableRowPreview: false,
+    getRowId: (row) => row.id,
+    initialState: {
+      sorting: [{ desc: SORT_DIRECTION.ASCENDING, id: "sourceStudy" }],
+    },
+    meta: { browserUrl: config.browserURL },
+    state: {
+      columnVisibility: {},
+    },
+  });
+};

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/table.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/table.tsx
@@ -1,0 +1,27 @@
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
+import { GridPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import { JSX } from "react";
+import { Table as CommonTable } from "../../../../../../../../../common/Table/table";
+import { useTable } from "./hook";
+import type { Props } from "./types";
+
+/**
+ * Tracker source studies table for the Source Studies tab.
+ * @param props - Component props.
+ * @param props.data - Tracker source studies.
+ * @returns table of tracker source studies, or empty state if no data.
+ */
+export const Table = ({ data }: Props): JSX.Element => {
+  const table = useTable(data);
+  return (
+    <FluidPaper elevation={0}>
+      <GridPaper>
+        {table.getRowCount() === 0 ? (
+          <div>No Source Studies</div>
+        ) : (
+          <CommonTable table={table} />
+        )}
+      </GridPaper>
+    </FluidPaper>
+  );
+};

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/types.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/types.ts
@@ -1,0 +1,5 @@
+import type { TrackerSourceStudy } from "../../../../../../../../../../@types/network";
+
+export interface Props {
+  data: TrackerSourceStudy[];
+}

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/viewBuilder.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/viewBuilder.tsx
@@ -12,7 +12,7 @@ const DOI_BASE_URL = "https://doi.org/";
 /**
  * Renders an HCA Data Repository link for the source study's HCA project.
  * @param ctx - Cell context.
- * @returns Link component if hcaProjectId exists, otherwise empty string.
+ * @returns Link component if hcaProjectId exists, otherwise null.
  */
 export function renderHCADataRepository(
   ctx: CellContext<TrackerSourceStudy, unknown>
@@ -41,7 +41,7 @@ export function renderHCADataRepository(
  */
 export function renderSourceStudy(
   ctx: CellContext<TrackerSourceStudy, string>
-): JSX.Element | null {
+): JSX.Element {
   const label = ctx.getValue();
   const { doi } = ctx.row.original;
   return C.Link({

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/viewBuilder.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/Table/tracker/viewBuilder.tsx
@@ -1,0 +1,53 @@
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import type { CellContext } from "@tanstack/react-table";
+import type { JSX } from "react";
+import * as C from "../../../../../../../../..";
+import type { TrackerSourceStudy } from "../../../../../../../../../../@types/network";
+
+const DOI_BASE_URL = "https://doi.org/";
+
+/**
+ * Renders an HCA Data Repository link for the source study's HCA project.
+ * @param ctx - Cell context.
+ * @returns Link component if hcaProjectId exists, otherwise empty string.
+ */
+export function renderHCADataRepository(
+  ctx: CellContext<TrackerSourceStudy, unknown>
+): JSX.Element | null {
+  const { hcaProjectId } = ctx.row.original;
+
+  if (!hcaProjectId) return null;
+
+  const { browserUrl } = ctx.table.options.meta as { browserUrl?: string };
+
+  if (!browserUrl) return null;
+
+  return C.Link({
+    label: C.OpenInNewIcon({}),
+    rel: REL_ATTRIBUTE.NO_OPENER_NO_REFERRER,
+    target: ANCHOR_TARGET.BLANK,
+    url: `${browserUrl}/projects/${hcaProjectId}`,
+  });
+}
+
+/**
+ * Renders the source study citation as a link to the DOI.
+ * Uses getValue() to get the formatted citation from the accessorFn.
+ * @param ctx - Cell context with string value from buildSourceStudy accessor.
+ * @returns Link component with DOI URL, or plain label if no DOI.
+ */
+export function renderSourceStudy(
+  ctx: CellContext<TrackerSourceStudy, string>
+): JSX.Element | null {
+  const label = ctx.getValue();
+  const { doi } = ctx.row.original;
+  return C.Link({
+    label,
+    rel: REL_ATTRIBUTE.NO_OPENER_NO_REFERRER,
+    target: ANCHOR_TARGET.BLANK,
+    url: doi ? `${DOI_BASE_URL}${doi}` : "",
+  });
+}

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/mainColumn.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/mainColumn.tsx
@@ -1,0 +1,17 @@
+import { BackPageContentSingleColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
+import { JSX } from "react";
+import { useAtlas } from "../../../../../../../../contexts/atlasContext";
+import { Table as TrackerSourceStudiesTable } from "./Table/tracker/table";
+
+/**
+ * Main column for the Source Studies tab.
+ * @returns source studies content.
+ */
+export const MainColumn = (): JSX.Element => {
+  const { trackerSourceStudies = [] } = useAtlas();
+  return (
+    <BackPageContentSingleColumn>
+      <TrackerSourceStudiesTable data={trackerSourceStudies} />
+    </BackPageContentSingleColumn>
+  );
+};

--- a/components/HCABioNetworks/Network/Atlas/components/common/Tabs/tabs.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/common/Tabs/tabs.tsx
@@ -6,11 +6,12 @@ import {
 import {
   NETWORKS_ATLAS_PATTERN,
   NETWORK_ATLAS_DATASETS_PATTERN,
+  NETWORK_ATLAS_SOURCE_STUDIES_PATTERN,
 } from "constants/routes";
 import { useAtlas } from "contexts/atlasContext";
 import { useRouter } from "next/router";
 
-const TABS = [
+const BASE_TABS = [
   {
     label: "Atlas Overview",
     value: NETWORKS_ATLAS_PATTERN,
@@ -21,12 +22,22 @@ const TABS = [
   },
 ];
 
+const TRACKER_TABS = [
+  ...BASE_TABS,
+  {
+    label: "Source Studies",
+    value: NETWORK_ATLAS_SOURCE_STUDIES_PATTERN,
+  },
+];
+
 export const Tabs = (): JSX.Element => {
   const router = useRouter();
   const {
     atlas: { path: atlasPath },
     network: { path: networkPath },
+    trackerSourceStudies = [],
   } = useAtlas();
+  const tabs = trackerSourceStudies.length > 0 ? TRACKER_TABS : BASE_TABS;
 
   const handleTabChanged = (value: TabValue): void => {
     router.push({
@@ -39,7 +50,7 @@ export const Tabs = (): JSX.Element => {
     <DXTabs
       onTabChange={handleTabChanged}
       value={router.pathname}
-      tabs={TABS}
+      tabs={tabs}
     />
   );
 };

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -7,6 +7,7 @@ export { DownloadIcon } from "@databiosphere/findable-ui/lib/components/common/C
 export { FacebookIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/FacebookIcon/facebookIcon";
 export { GitHubIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/GitHubIcon/gitHubIcon";
 export { LinkedInIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/LinkedInIcon/linkedInIcon";
+export { OpenInNewIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/OpenInNewIcon/openInNewIcon";
 export { SlackIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SlackIcon/slackIcon";
 export { XIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/XIcon/xIcon";
 export { YouTubeIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/YouTubeIcon/youTubeIcon";

--- a/pages/hca-bio-networks/[network]/atlases/[atlas]/source-studies.tsx
+++ b/pages/hca-bio-networks/[network]/atlases/[atlas]/source-studies.tsx
@@ -1,0 +1,103 @@
+import { Detail } from "@databiosphere/findable-ui/lib/components/Detail/detail";
+import type {
+  GetStaticPaths,
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+  InferGetStaticPropsType,
+} from "next";
+import type { ParsedUrlQuery } from "querystring";
+import { JSX } from "react";
+import type {
+  Atlas,
+  Network,
+  TrackerSourceStudy,
+} from "../../../../../@types/network";
+import {
+  fetchTrackerSourceStudies,
+  resolveTrackerAtlasId,
+} from "../../../../../apis/tracker/api";
+import { Hero } from "../../../../../components/HCABioNetworks/Network/Atlas/components/common/Hero/hero";
+import { Tabs } from "../../../../../components/HCABioNetworks/Network/Atlas/components/common/Tabs/tabs";
+import { MainColumn } from "../../../../../components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/mainColumn";
+import { NETWORKS } from "../../../../../constants/networks";
+import { AtlasProvider } from "../../../../../contexts/atlasContext";
+
+interface Params extends ParsedUrlQuery {
+  atlas: string;
+  network: string;
+}
+
+interface Props {
+  atlas: Atlas;
+  network: Network;
+  pageTitle: string;
+  trackerSourceStudies: TrackerSourceStudy[];
+}
+
+/**
+ * Only generate paths for tracker-sourced atlases.
+ * @returns static paths for tracker atlases.
+ */
+export const getStaticPaths: GetStaticPaths<Params> = async () => {
+  const paths: Array<{ params: Params }> = [];
+  NETWORKS.forEach((network) => {
+    network.atlases.forEach((atlas) => {
+      if (atlas.tracker) {
+        paths.push({ params: { atlas: atlas.path, network: network.path } });
+      }
+    });
+  });
+  return { fallback: false, paths };
+};
+
+export const getStaticProps: GetStaticProps<Props> = async (
+  context: GetStaticPropsContext
+): Promise<GetStaticPropsResult<Props>> => {
+  const { atlas: atlasParam, network: networkParam } = context.params ?? {};
+
+  const network = NETWORKS.find(({ path }) => path === networkParam) as Network;
+  const atlas = network.atlases.find(
+    ({ path }) => path === atlasParam
+  ) as Atlas;
+  const { tracker } = atlas;
+
+  if (!tracker) return { notFound: true };
+
+  const atlasId = await resolveTrackerAtlasId(
+    tracker.shortNameSlug,
+    tracker.version
+  );
+
+  const trackerSourceStudies = await fetchTrackerSourceStudies(atlasId);
+
+  return {
+    props: {
+      atlas: { ...atlas, trackerAtlasId: atlasId },
+      network,
+      pageTitle: `${atlas.name} - Source Studies`,
+      trackerSourceStudies,
+    },
+  };
+};
+
+const Page = ({
+  atlas,
+  network,
+  trackerSourceStudies,
+}: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element => {
+  return (
+    <AtlasProvider
+      value={{
+        atlas,
+        network,
+        projectsResponses: [],
+        trackerSourceStudies,
+      }}
+    >
+      <Detail mainColumn={<MainColumn />} Tabs={<Tabs />} top={<Hero />} />
+    </AtlasProvider>
+  );
+};
+
+export default Page;


### PR DESCRIPTION
## Summary
- Add new Source Studies tab at `/hca-bio-networks/gut/atlases/gut-v1-0/source-studies`
- Dynamic tabs — "Source Studies" tab only appears when `trackerSourceStudies` data is present
- Own `getStaticPaths` (tracker atlases only) and `getStaticProps` (fetches only source studies)
- Columns: Source Study (citation linked via DOI), Title, Datasets count, HCA Data Repository (OpenInNewIcon link)
- `buildSourceStudy` accessor formats citations: "Author (Year) Journal" or "Author - Unpublished"
- `renderHCADataRepository` reads `browserUrl` from table meta to link to HCA Data Explorer
- Updated `TrackerSourceStudy` type with nullable `doi`/`journal`/`publicationDate` and added `contactEmail`/`doiStatus`/`hcaProjectId`/`id` fields
- Exported `OpenInNewIcon` from components index

## Test plan
- [x] TypeScript compiles cleanly
- [x] ESLint passes
- [x] Prettier passes
- [x] Visit `/hca-bio-networks/gut/atlases/gut-v1-0/source-studies` — Source Studies tab shows studies with DOI links
- [x] Visit `/hca-bio-networks/gut/atlases/gut-v1-0` — "Source Studies" tab appears in navigation
- [x] Visit `/hca-bio-networks/lung/atlases/lung-v1-0` — No "Source Studies" tab (non-tracker atlas)

Closes #2940

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1486" height="1089" alt="image" src="https://github.com/user-attachments/assets/ea0b67ab-7292-4496-b80f-55dc086b0c1c" />
