### PR TITLE
feat: gut atlas v1.0 network-level integration (#2942)

### DIFF
--- a/utils/networkPages.ts
+++ b/utils/networkPages.ts
@@ -34,28 +34,30 @@ export async function getContentStaticProps(
   // Fetch CELLxGENE datasets for the network atlases.
   const cxgDatasets = await fetchCXGDatasetsForAtlases(network.atlases);
 
-  // Populate integrated atlases for tracker-sourced atlases.
-  for (const atlas of network.atlases) {
-    if (atlas.tracker) {
-      const atlasId = await resolveTrackerAtlasId(
-        atlas.tracker.shortNameSlug,
-        atlas.tracker.version
-      );
+  // Populate integrated atlases for tracker-sourced atlases immutably.
+  const atlases = await Promise.all(
+    network.atlases.map(async (atlas) => {
+      if (!atlas.tracker) return atlas;
+      const { shortNameSlug, version } = atlas.tracker;
+      const atlasId = await resolveTrackerAtlasId(shortNameSlug, version);
       const componentAtlases = await fetchTrackerComponentAtlases(atlasId);
-      atlas.integratedAtlases = componentAtlases.map((component) =>
-        mapTrackerComponentAtlasToIntegratedAtlas(
-          component,
-          network.key,
-          atlas.tracker!.shortNameSlug,
-          atlas.tracker!.version
-        )
-      );
-    }
-  }
+      return {
+        ...atlas,
+        integratedAtlases: componentAtlases.map((component) =>
+          mapTrackerComponentAtlasToIntegratedAtlas(
+            component,
+            network.key,
+            shortNameSlug,
+            version
+          )
+        ),
+      };
+    })
+  );
 
   return {
     props: {
-      network: processNetwork(network, cxgDatasets),
+      network: processNetwork({ ...network, atlases }, cxgDatasets),
       pageTitle: `${network.name} - ${tabName}`,
     },
   };

--- a/utils/networkPages.ts
+++ b/utils/networkPages.ts
@@ -1,11 +1,16 @@
-import {
+import type {
   GetStaticPaths,
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from "next";
-import { Network, NetworkParam } from "../@types/network";
+import type { Network, NetworkParam } from "../@types/network";
+import {
+  fetchTrackerComponentAtlases,
+  resolveTrackerAtlasId,
+} from "../apis/tracker/api";
 import { NETWORKS } from "../constants/networks";
 import { fetchCXGDatasetsForAtlases, processNetwork } from "./network";
+import { mapTrackerComponentAtlasToIntegratedAtlas } from "./trackerNetwork";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   return {
@@ -28,6 +33,26 @@ export async function getContentStaticProps(
 
   // Fetch CELLxGENE datasets for the network atlases.
   const cxgDatasets = await fetchCXGDatasetsForAtlases(network.atlases);
+
+  // Populate integrated atlases for tracker-sourced atlases.
+  for (const atlas of network.atlases) {
+    if (atlas.tracker) {
+      const atlasId = await resolveTrackerAtlasId(
+        atlas.tracker.shortNameSlug,
+        atlas.tracker.version
+      );
+      const componentAtlases = await fetchTrackerComponentAtlases(atlasId);
+      atlas.integratedAtlases = componentAtlases.map((component) =>
+        mapTrackerComponentAtlasToIntegratedAtlas(
+          component,
+          network.key,
+          atlas.tracker!.shortNameSlug,
+          atlas.tracker!.version
+        )
+      );
+    }
+  }
+
   return {
     props: {
       network: processNetwork(network, cxgDatasets),


### PR DESCRIPTION
## Summary
- Update `utils/networkPages.ts` to fetch tracker component atlases at build time for tracker-sourced atlases
- Populates `integratedAtlases` on the network overview page so the gut atlas shows correct cell counts, tissues, and diseases in the summary
- Reuses existing `resolveTrackerAtlasId`, `fetchTrackerComponentAtlases`, and `mapTrackerComponentAtlasToIntegratedAtlas`
- `fetchCXGDatasetsForAtlases` already safely skips tracker atlases (no `cxgId`)

## Test plan
- [x] TypeScript compiles cleanly
- [x] ESLint passes
- [x] Prettier passes
- [x] Visit `/hca-bio-networks/gut` — network overview shows gut atlas with cell count, tissues, diseases
- [x] Visit `/hca-bio-networks/lung` — lung network unchanged

Closes #2942

🤖 Generated with [Claude Code](https://claude.com/claude-code)

![Uploading image.png…]()
