### PR TITLE
chore: upgrade findable-ui to v51 and remove next-auth (#3001)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next",
       "version": "2.9.2",
       "dependencies": {
-        "@databiosphere/findable-ui": "^50.8.0",
+        "@databiosphere/findable-ui": "^51.0.1",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3.0.1",
@@ -25,7 +25,6 @@
         "isomorphic-dompurify": "^2",
         "ky": "^1",
         "next": "^15",
-        "next-auth": "^4",
         "next-compose-plugins": "^2.2.1",
         "next-mdx-remote": "^5",
         "react": "^19",
@@ -645,9 +644,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "50.8.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.8.0.tgz",
-      "integrity": "sha512-elk72FEmxsdxOheZG/aXvmkraEkm+t1NJd7sPjYvHx8/Sdpgpo6kFSYPgt39eOSZ5/zAKMx8u97fkbdwf/2oaQ==",
+      "version": "51.0.1",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.1.tgz",
+      "integrity": "sha512-kHHf38QoQUJP+LQAPFKmGuOdZWWeb8Fjer+1CgIa8CryAnGI4HGNQT1KetrnMP0KuPRVOw3VmQOtzsynSdauKg==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"
@@ -684,6 +683,11 @@
         "unified": "^11.0.5",
         "uuid": "^13.0.0",
         "yup": "^1.7.1"
+      },
+      "peerDependenciesMeta": {
+        "next-auth": {
+          "optional": true
+        }
       }
     },
     "node_modules/@digitak/esrun": {
@@ -2627,6 +2631,8 @@
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
       "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -4544,6 +4550,8 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8567,6 +8575,8 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
       "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -10202,6 +10212,8 @@
       "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.13.tgz",
       "integrity": "sha512-sgObCfcfL7BzIK76SS5TnQtc3yo2Oifp/yIpfv6fMfeBOiBJkDWF3A2y9+yqnmJ4JKc2C+nMjSjmgDeTwgN1rQ==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@panva/hkdf": "^1.0.2",
@@ -10234,6 +10246,8 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -10327,7 +10341,9 @@
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -10350,6 +10366,8 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10472,6 +10490,8 @@
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
       "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
       }
@@ -10481,6 +10501,8 @@
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
       "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "jose": "^4.15.9",
         "lru-cache": "^6.0.0",
@@ -10496,6 +10518,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -10786,6 +10810,8 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
       "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -10796,6 +10822,8 @@
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
       "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "pretty-format": "^3.8.0"
       },
@@ -10863,7 +10891,9 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -13265,7 +13295,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/yaml": {
       "version": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "get-cellxgene-projects": "esrun ./scripts/get-cellxgene-projects.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^50.8.0",
+    "@databiosphere/findable-ui": "^51.0.1",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3.0.1",
@@ -34,7 +34,6 @@
     "isomorphic-dompurify": "^2",
     "ky": "^1",
     "next": "^15",
-    "next-auth": "^4",
     "next-compose-plugins": "^2.2.1",
     "next-mdx-remote": "^5",
     "react": "^19",


### PR DESCRIPTION
## Summary
- Upgraded `@databiosphere/findable-ui` from ^50.8.0 to ^51.0.1
- Removed `next-auth` dependency (no longer needed — not imported anywhere, now optional peer dep in findable-ui)
- Ran `npm audit fix` — 4 remaining vulnerabilities are unfixable (esbuild/esrun no fix available, next-mdx-remote needs v6 breaking change)

Closes #3001

## Test plan
- [x] TypeScript compiles cleanly
- [x] Lint passes
- [x] Dev build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)