### PR TITLE
chore: upgrade findable-ui to v51.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next",
       "version": "2.10.1",
       "dependencies": {
-        "@databiosphere/findable-ui": "^51.0.1",
+        "@databiosphere/findable-ui": "^51.1.0",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3.0.1",
@@ -644,9 +644,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "51.0.1",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.1.tgz",
-      "integrity": "sha512-kHHf38QoQUJP+LQAPFKmGuOdZWWeb8Fjer+1CgIa8CryAnGI4HGNQT1KetrnMP0KuPRVOw3VmQOtzsynSdauKg==",
+      "version": "51.1.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.1.0.tgz",
+      "integrity": "sha512-aWy0zOOGim5xoJvWes1v/mqKSobBUlGmfZt4uIMp5f+oNKEFlAA27CSJ01SsbhWQKgpPdZT3f+kXxfYG0FDk+A==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "get-cellxgene-projects": "esrun ./scripts/get-cellxgene-projects.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^51.0.1",
+    "@databiosphere/findable-ui": "^51.1.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
## Summary

Upgrade `@databiosphere/findable-ui` to v51.1.0 which includes the filter param validation fix ([findable-ui#899](https://github.com/DataBiosphere/findable-ui/pull/899)).

This app does not use `ExploreStateProvider` so the crash loop bug does not apply here. This is a straightforward dependency upgrade to stay current.

Closes #3019

## Reference

- Umbrella: DataBiosphere/findable-ui#900
- Findable-ui fix: https://github.com/DataBiosphere/findable-ui/pull/899

## Test plan
- [x] Lint passes
- [x] Prettier passes
- [x] TypeScript compiles
- [x] Site loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)