### PR TITLE
ci: stop assigning Dependabot PRs to NoopDog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
     # bumps into a single PR; major bumps still open individual PRs
     schedule:
       interval: "monthly"
-    assignees:
-      - "NoopDog"
     open-pull-requests-limit: 5
     groups:
       minor-and-patch:
@@ -24,8 +22,6 @@ updates:
     directory: "/analytics"
     schedule:
       interval: "monthly"
-    assignees:
-      - "NoopDog"
     groups:
       all-updates:
         patterns:


### PR DESCRIPTION
Closes #3169

## What changed

Removed the `assignees:` block (a single `NoopDog` entry) from both the **npm** and **pip** `package-ecosystem` entries in `.github/dependabot.yml`. Nothing else is touched — the monthly schedule, `open-pull-requests-limit: 5`, and both `groups` blocks are unchanged.

## Why

Dependabot was auto-assigning every dependency-bump PR to one person (NoopDog). Dozens of open bumps accumulated on that person's assigned list and flooded the CC All Projects board view, which filters by assignee. Leaving the PRs unassigned keeps them off that view without changing how Dependabot opens or groups them.

## Assumptions I made

- Unassigned is the desired end state. The linked issue notes the alternative — repointing the assignment to a different owner or a rotation — and no such owner was specified, so the block was removed rather than repointed.
- No reviewer settings existed to preserve (there were none in the file), so review-request behavior is unaffected.

## How to verify

Maps to the issue's definition of done:

- [x] `assignees` removed from the npm entry — see the diff, lines under `package-ecosystem: "npm"`.
- [x] `assignees` removed from the pip entry — see the diff, lines under `package-ecosystem: "pip"`.
- [x] `dependabot.yml` still parses / no other keys altered — `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` succeeds; ecosystems are still `['npm','pip']`.
- [ ] After merge, a newly opened Dependabot PR has no assignee — confirm on the next scheduled run (or trigger one via Insights → Dependency graph → Dependabot → "Check for updates") that the resulting PR opens unassigned.